### PR TITLE
fix: add gnome 44

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,5 +6,5 @@
   "description": "Tightly integrates Fig with GNOME shell",
   "gettext-domain": "fig-gnome-integration",
   "settings-schema": "org.gnome.shell.extensions.fig-gnome-integration",
-  "shell-version": ["41", "42", "43"]
+  "shell-version": ["41", "42", "43", "44"]
 }


### PR DESCRIPTION
Working normally on Gnome 44:

![Screenshot from 2023-04-19 16-12-00](https://user-images.githubusercontent.com/17055027/233177051-5abbba15-0a03-49d2-bc99-862653ec7990.png)
